### PR TITLE
fix: :ambulance: int overflow bug on the closest color comparison

### DIFF
--- a/examples/basic_color_sensor/basic_color_sensor.ino
+++ b/examples/basic_color_sensor/basic_color_sensor.ino
@@ -1,0 +1,44 @@
+#include <compkit.h>
+
+compkit::color_sensor<2> sensorDireita(A0, 2, 3, 4);
+size_t verde;
+size_t amarelo;
+
+void setup() {
+  Serial.begin(9600);
+
+  delay(3000);
+  compkit::color_point leitura1;
+  sensorDireita.read(leitura1);
+  verde = sensorDireita.add_color_point(leitura1);
+
+  Serial.print(verde);
+  Serial.print(": ");
+  compkit::print_color(leitura1);
+  Serial.println("");
+
+  delay(3000);
+  compkit::color_point leitura2;
+  sensorDireita.read(leitura2);
+  amarelo = sensorDireita.add_color_point(leitura2);
+
+  Serial.print(amarelo);
+  Serial.print(": ");
+  compkit::print_color(leitura2);
+  Serial.println("");
+
+  delay(3000);
+}
+
+void loop() {
+  compkit::color_point leituraCorDireita;
+  sensorDireita.read(leituraCorDireita);
+
+  int corAtual = sensorDireita.closest_color(leituraCorDireita);
+  if(corAtual == verde) {
+    Serial.println("sensorDireita: Verde");
+  } else if(corAtual == amarelo) {
+    Serial.println("sensorDireita: Amarelo");
+  }
+  delay(100);
+}

--- a/library.json
+++ b/library.json
@@ -38,6 +38,13 @@
       "files": [
         "color_sensor_with_serial.ino"
       ]
+    },
+    {
+      "name": "Basic Color Sensor Example",
+      "base": "examples/basic_color_sensor",
+      "files": [
+        "basic_color_sensor.ino"
+      ]
     }
   ],
   "export": {

--- a/src/color_sensor.h
+++ b/src/color_sensor.h
@@ -35,6 +35,18 @@ struct color_point {
   const int &operator[](size_t index) const { return data[index]; }
 };
 
+void print_color(color_point &point) {
+  Serial.print("(");
+  Serial.print(point[0]);
+  Serial.print(", ");
+  Serial.print(point[1]);
+  Serial.print(", ");
+  Serial.print(point[2]);
+  Serial.print(", ");
+  Serial.print(point[3]);
+  Serial.print(")");
+}
+
 template <size_t n_color_points = 1> class color_sensor {
 private:
   unsigned int _led_pin[3]; // {red, green, blue}
@@ -88,8 +100,8 @@ public:
     point[3] = _color_points[index][3];
   }
 
-  int color_difference(color_point &point1, color_point &point2) {
-    int diff = 0;
+  int32_t color_difference(color_point &point1, color_point &point2) {
+    int32_t diff = 0;
     for(size_t i = 0; i < 3; i++) {
       diff += compkit_abs(point1[i] - point2[i]);
     }
@@ -97,10 +109,10 @@ public:
   }
 
   int closest_color(color_point &point) {
-    int min_diff      = 99999;
+    int32_t min_diff  = 99999;
     int closest_color = 0;
     for(size_t i = 0; i < _current_color_points; i++) {
-      int diff = 0;
+      int32_t diff = 0;
       for(size_t j = 0; j < 3; j++) {
         diff += compkit_abs(point[j] - _color_points[i][j]);
       }


### PR DESCRIPTION
# Descrição

- Corrige comparação da cor lida com a cor mais próxima calibrada.

## 🚨 Impacto das Alterações 🚨

- **Robô:** Compara as cores lidas corretamente.
- **Desenvolvedor:** N/A
